### PR TITLE
Add memoryUsage command

### DIFF
--- a/cmd/disable.go
+++ b/cmd/disable.go
@@ -25,7 +25,7 @@ import (
 
 // disableCmd represents the enable command
 var disableCmd = &cobra.Command{
-	Use:   "disable [SCALING_GROUP_NAME]",
+	Use:   "disable SCALING_GROUP_NAME",
 	Short: "Disables upscale/downscale alarm task",
 	Long:  `Will disable upscale or downscale event-trigger task`,
 	Args:  cobra.ExactArgs(1),

--- a/cmd/downscale.go
+++ b/cmd/downscale.go
@@ -25,7 +25,7 @@ import (
 
 // downscaleCmd represents the downscale command
 var downscaleCmd = &cobra.Command{
-	Use:   "downscale [SCALING_GROUP_NAME] [RETRY_COUNT] [RETRY_INTERVAL]",
+	Use:   "downscale SCALING_GROUP_NAME RETRY_COUNT RETRY_INTERVAL",
 	Short: "Remove all upscaled instance down to minimum instance.",
 	Long:  `Will remove all upscaled instance down to minimum instance`,
 	Args:  cobra.ExactArgs(3),

--- a/cmd/ecs/info.go
+++ b/cmd/ecs/info.go
@@ -1,0 +1,82 @@
+// Copyright © 2018 William Chanrico
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecs
+
+import (
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+)
+
+// InstanceInfo contains information about an instance
+type InstanceInfo struct {
+	IP           string
+	CPU          int
+	Memory       int
+	InstanceName string
+	InstanceType string
+	CreationTime string
+}
+
+// QueryInstanceList will query info of instances with matched hostgroup tag
+// The other tags are static: "Environment=production" and "Datacenter=alisg"
+func (c *Client) QueryInstanceList(hostgroup string) ([]InstanceInfo, error) {
+	req := ecs.CreateDescribeInstancesRequest()
+	req.PageSize = requests.NewInteger(100)
+	req.PageNumber = requests.NewInteger(1)
+	req.Tag = &[]ecs.DescribeInstancesTag{
+		ecs.DescribeInstancesTag{
+			Value: "production",
+			Key:   "Environment",
+		},
+		ecs.DescribeInstancesTag{
+			Value: "alisg",
+			Key:   "Datacenter",
+		},
+		ecs.DescribeInstancesTag{
+			Value: hostgroup,
+			Key:   "Hostgroup",
+		},
+	}
+
+	var instanceList []InstanceInfo
+
+	for totalCount := req.PageSize; totalCount == req.PageSize; {
+		resp, err := c.DescribeInstances(req)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range resp.Instances.Instance {
+			instance := resp.Instances.Instance[i]
+
+			instanceList = append(instanceList,
+				InstanceInfo{
+					// IP: instance.NetworkInterfaces.
+					// 	NetworkInterface[0].PrimaryIpAddress,
+					IP: instance.VpcAttributes.
+						PrivateIpAddress.IpAddress[0],
+					CPU:          instance.Cpu,
+					Memory:       instance.Memory,
+					InstanceName: instance.InstanceName,
+					CreationTime: instance.CreationTime,
+				},
+			)
+		}
+		req.PageNumber = requests.NewInteger(resp.PageNumber + 1)
+		totalCount = requests.NewInteger(len(resp.Instances.Instance))
+	}
+
+	return instanceList, nil
+}

--- a/cmd/ecs/ip.go
+++ b/cmd/ecs/ip.go
@@ -23,6 +23,7 @@ import (
 type IPInfo struct {
 	IP        string
 	ConsulTag string
+	IsRunning bool
 }
 
 // QueryIPList will query IP of instances with matched hostgroup tag
@@ -63,11 +64,17 @@ func (c *Client) QueryIPList(hostgroup string) ([]IPInfo, error) {
 				}
 			}
 
+			isRunning := false
+			if instance.Status == "Running" {
+				isRunning = true
+			}
+
 			ipList = append(ipList,
 				IPInfo{
 					IP: instance.NetworkInterfaces.
 						NetworkInterface[0].PrimaryIpAddress,
 					ConsulTag: consulTag,
+					IsRunning: isRunning,
 				},
 			)
 		}

--- a/cmd/enable.go
+++ b/cmd/enable.go
@@ -25,7 +25,7 @@ import (
 
 // enableCmd represents the enable command
 var enableCmd = &cobra.Command{
-	Use:   "enable [SCALING_GROUP_NAME]",
+	Use:   "enable SCALING_GROUP_NAME",
 	Short: "Enables upscale/downscale alarm task",
 	Long:  `Will enable upscale or downscale event-trigger task`,
 	Args:  cobra.ExactArgs(1),

--- a/cmd/et.go
+++ b/cmd/et.go
@@ -30,7 +30,7 @@ var (
 
 // etCmd represents the et command
 var etCmd = &cobra.Command{
-	Use:   "et [SCALING_GROUP_NAME]",
+	Use:   "et SCALING_GROUP_NAME",
 	Short: "Query Event-Trigger Task(s) from aliyun.",
 	Long: `Query Event-Trigger Task(s) from aliyun. Requires SCALING_GROUP_NAME
 because Event-Trigger Task can't be searched by name, and scaling group name is a better
@@ -85,8 +85,9 @@ compromise than using an Event-Trigger Task ID`,
 			color.Red(">>> BEGIN - USERDATA")
 			color.Blue(sgList[i].UserData)
 			color.Red("<<< END - USERDATA")
-			color.Yellow("--- https://essnew.console.aliyun.com/?spm=5176.2020520101.203.4." +
-				"278f7d33hepSMf#/task/alarm/region/ap-southeast-1 ---\n")
+			color.Yellow("--- https://essnew.console.aliyun.com/"+
+				"?spm=5176.2020520101.203.4.65837d33Df8Y22#/detail/ap-southeast-1/"+
+				"%v/basicInfo ---\n", sgList[i].ScalingGroupID)
 		}
 	},
 }

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -27,7 +27,7 @@ var noConsulTags bool
 
 // ipCmd represents the ip command
 var ipCmd = &cobra.Command{
-	Use:   "ip [HOSTGROUP]",
+	Use:   "ip HOSTGROUP",
 	Short: "Query active IP(s) of a service hostgroup",
 	Long: `Query IP(s) of a service hostgroup with these tags:
 - Env: production

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -24,6 +24,7 @@ import (
 
 var hostGroup string
 var noConsulTags bool
+var includeStoppedInstances bool
 
 // ipCmd represents the ip command
 var ipCmd = &cobra.Command{
@@ -32,7 +33,10 @@ var ipCmd = &cobra.Command{
 	Long: `Query IP(s) of a service hostgroup with these tags:
 - Env: production
 - Datacenter: alisg
-- Hostgroup: [HOSTGROUP]`,
+- Hostgroup: {HOSTGROUP}
+
+And by default will only show running instance(s),
+Use --all flag to include stopped instance(s).`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Print("Querying IP(s) of hostgroup ")
@@ -46,6 +50,9 @@ var ipCmd = &cobra.Command{
 
 		color.Yellow("\n---")
 		for i := range ipList {
+			if !includeStoppedInstances && !ipList[i].IsRunning {
+				continue
+			}
 			color.Set(color.FgWhite)
 			fmt.Printf("%v", ipList[i].IP)
 
@@ -64,5 +71,6 @@ var ipCmd = &cobra.Command{
 
 func init() {
 	ipCmd.Flags().BoolVarP(&noConsulTags, "no-tag", "n", false, "Hide consul_tags")
+	ipCmd.Flags().BoolVarP(&includeStoppedInstances, "all", "a", false, "Include stopped instance(s)")
 	rootCmd.AddCommand(ipCmd)
 }

--- a/cmd/memoryUsage.go
+++ b/cmd/memoryUsage.go
@@ -1,0 +1,94 @@
+// Copyright © 2018 William Chanrico
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/williamchanrico/ali/cmd/ecs"
+	"github.com/williamchanrico/ali/cmd/util"
+)
+
+const timeFormat = "2006-01-02 15:04:05"
+
+// memoryUsageCmd represents the memoryUsage command
+var memoryUsageCmd = &cobra.Command{
+	Use:   "memoryUsage HOSTGROUP_A,HOSTGROUP_B,...",
+	Short: "Get and calculate the memory usage of instance(s) by hostgroups",
+	Long: `Get and calculate the memory usage of instance(s) by hostgroups.
+HOSTGROUP_LIST is separated by comma (default, use -d flag to specify delimiter).
+
+Will output the following information: <ip_address> <creation_time_in_utc> <memory_mb>,
+along with total memory usage.
+`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		inv := strings.Split(args[0], ",")
+
+		ecs := ecs.New()
+
+		totalMem := 0
+		summary := map[string]int{}
+		for _, hostgroup := range inv {
+			hgTotalMem := 0
+
+			instanceList, err := ecs.QueryInstanceList(hostgroup)
+			if err != nil {
+				color.Red("Failed to query instance list:", err)
+			}
+
+			if len(instanceList) == 0 {
+				color.Red("!!! Hostgroup %v has no instance(s) !!!\n", hostgroup)
+				continue
+			}
+
+			color.Green("[%s]", hostgroup)
+			for _, i := range instanceList {
+				creationTime, err := util.ParseTimeStr(i.CreationTime)
+				if err != nil {
+					creationTime = time.Time{}
+				}
+				// if creationTime.Before(time.Date(2018, 2, 1, 0, 0, 0, 0, time.UTC)) {
+				// }
+
+				color.Yellow("%s\t%s\t%dMB", i.IP, creationTime.Format(timeFormat), i.Memory)
+				hgTotalMem += i.Memory
+			}
+			totalMem += hgTotalMem
+			summary[hostgroup] = hgTotalMem
+
+			color.White("------------------\n")
+			color.White("Mem usage:\t\t\t\t%dMB\n\n", hgTotalMem)
+		}
+
+		color.Green("Summary")
+		color.White("==============================================")
+		for k, v := range summary {
+			fmt.Printf("%dMB\t\t%s\n", v, k)
+		}
+
+		color.White("==============================================")
+		color.Green("Grand total: %dMB\n\n", totalMem)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(memoryUsageCmd)
+}

--- a/cmd/price.go
+++ b/cmd/price.go
@@ -24,8 +24,8 @@ import (
 
 // priceCmd represents the price command
 var priceCmd = &cobra.Command{
-	Use:   "price [INSTANCE_TYPE] {REGION_ID}",
-	Short: "Show real-time price per hour for the instance type in USD",
+	Use:   "price INSTANCE_TYPE [REGION_ID]",
+	Short: "Show real-time price per hour for the instance type in USD (default region: ap-southeast-1).",
 	Long: `Will query real-time price per hour in USD and output the specified instance type
 pricing (default region is Singapore ap-southeast-1)`,
 	Args: cobra.MinimumNArgs(1),

--- a/cmd/sg.go
+++ b/cmd/sg.go
@@ -24,7 +24,7 @@ import (
 
 // sgCmd represents the sg command
 var sgCmd = &cobra.Command{
-	Use:   "sg [SCALING_GROUP_NAME]",
+	Use:   "sg SCALING_GROUP_NAME",
 	Short: "Query active ScalingGroup of a service by name",
 	Long: `Query active ScalingGroup of a service by name. Will show
 relatively useful info about the scaling group for day to day use.`,

--- a/cmd/upscale.go
+++ b/cmd/upscale.go
@@ -25,7 +25,7 @@ import (
 
 // upscaleCmd represents the upscale command
 var upscaleCmd = &cobra.Command{
-	Use:   "upscale [SCALING_GROUP_NAME] [NUM_OF_INSTANCES_TO_ADD]",
+	Use:   "upscale SCALING_GROUP_NAME NUM_OF_INSTANCES_TO_ADD",
 	Short: "Upscale a scaling group to add specified number of instances.",
 	Long: `Upscale a scaling group to add specified number of instances.
 Will temporarily change the upscale scaling rule to match NUM_OF_INSTANCES_TO_ADD number,

--- a/cmd/util/time.go
+++ b/cmd/util/time.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"time"
+)
+
+// ParseTimeStr will parse date string into time
+func ParseTimeStr(str string) (time.Time, error) {
+	if str == "" {
+		return time.Time{}, nil
+	}
+
+	timeLayout := []string{
+		"2006-01-02T15:04:05.000Z",
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04Z",
+	}
+
+	var err error
+	var t time.Time
+	for i := range timeLayout {
+		t, err = time.Parse(timeLayout[i], str)
+		if err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, err
+}


### PR DESCRIPTION
- Add `memoryUsage` command to calculate memory usage by hostgroups
- Refactor usage example in `help` page
- Exclude `Stopped` instance(s) from `ip` command
- Add `--all` flag to `ip` command to include stopped instance(s)